### PR TITLE
Tweaks to how we load data from other sources

### DIFF
--- a/test_loading_types.sh
+++ b/test_loading_types.sh
@@ -4,7 +4,7 @@
 set -e
 
 echo "Loading data from local extraction into Duckdb..."
-uv run src/process_catalog.py --catalog anntaylor --local --download /tmp/octogen.extractor
+uv run src/process_catalog.py --catalog anntaylor --local --download /tmp/octogen.extractor/anntaylor
 mv anntaylor_catalog.duckdb anntaylor_catalog.duckdb.extractor
 echo "✓ First test complete"
 
@@ -14,7 +14,7 @@ mv anntaylor_catalog.duckdb anntaylor_catalog.duckdb.gcs
 echo "✓ Second tests complete"
 
 echo "Loading data from octogendb dump into Duckdb..."
-uv run src/process_catalog.py --catalog anntaylor --local --download /tmp/octogendb-downloader
+uv run src/process_catalog.py --catalog anntaylor --local --download /tmp/octogendb-downloader/catalog=anntaylor
 mv anntaylor_catalog.duckdb anntaylor_catalog.duckdb.octogendb
 echo "✓ Third tests complete"
 


### PR DESCRIPTION
This pull request includes several changes to the `src/load_to_db.py` and `src/process_catalog.py` files to improve the handling of catalog data, as well as updates to the `test_loading_types.sh` script. The most important changes include adding error handling for missing parquet files, updating the database path handling, and refactoring the `process_catalog` function.

Improvements to error handling and logging:

* [`src/load_to_db.py`](diffhunk://#diff-2103d12576bdb397617cea14bd69c428295413d86d990180f9cc73f6a0c1229fL300-R308): Added error handling for missing parquet files and updated log messages to provide more detailed information.

Database path handling:

* [`src/load_to_db.py`](diffhunk://#diff-2103d12576bdb397617cea14bd69c428295413d86d990180f9cc73f6a0c1229fR285-R290): Modified the `load_parquet_files_to_db` function to include a `create_if_missing` parameter and updated the database path handling accordingly.

Refactoring and cleanup:

* [`src/load_to_db.py`](diffhunk://#diff-2103d12576bdb397617cea14bd69c428295413d86d990180f9cc73f6a0c1229fL384-L491): Removed the `load_data` function and its associated code, which was responsible for creating and populating the additional attributes table.

Updates to catalog processing:

* [`src/process_catalog.py`](diffhunk://#diff-d65fbc68f1983df87827f02586acc336a185b7da8e3b63a195e1a6527341c355R30-L42): Refactored the `process_catalog` function to include additional environment variable handling and improved the database path handling. [[1]](diffhunk://#diff-d65fbc68f1983df87827f02586acc336a185b7da8e3b63a195e1a6527341c355R30-L42) [[2]](diffhunk://#diff-d65fbc68f1983df87827f02586acc336a185b7da8e3b63a195e1a6527341c355L52-L59)

Test script updates:

* [`test_loading_types.sh`](diffhunk://#diff-f800ae5d00f7f9f0b26cf41090f9e48e794967cc78f363549b24165e2ac7d80dL7-R7): Updated the test script to reflect changes in the catalog download paths and ensure correct handling of local data. [[1]](diffhunk://#diff-f800ae5d00f7f9f0b26cf41090f9e48e794967cc78f363549b24165e2ac7d80dL7-R7) [[2]](diffhunk://#diff-f800ae5d00f7f9f0b26cf41090f9e48e794967cc78f363549b24165e2ac7d80dL17-R17)